### PR TITLE
Set pipefail so a pg_dump command will cause a failure

### DIFF
--- a/postgres-backup-s3/backup.sh
+++ b/postgres-backup-s3/backup.sh
@@ -1,6 +1,7 @@
 #! /bin/sh
 
 set -e
+set -o pipefail
 
 if [ "${S3_ACCESS_KEY_ID}" = "**None**" ]; then
   echo "You need to set the S3_ACCESS_KEY_ID environment variable."


### PR DESCRIPTION
Currently if pg_dump fails the script is still 'successful' because the output is piped into a command which succeeds, not great!