### PR TITLE
Update install.sh

### DIFF
--- a/mailcatcher/install.sh
+++ b/mailcatcher/install.sh
@@ -7,7 +7,7 @@ set -e
 apt-get update && apt-get install -y ruby ruby-dev build-essential sqlite3 libsqlite3-dev
 
 # install mailcatcher
-gem install mailcatcher --no-ri --no-rdoc
+gem install mailcatcher -v 0.5.12 --no-ri --no-rdoc
 
 # cleanup package manager
 apt-get remove --purge -y build-essential ruby-dev libsqlite3-dev && apt-get autoclean && apt-get clean


### PR DESCRIPTION
Force v0.5.12 to avoid crash with UTF-8 mails. See https://github.com/sj26/mailcatcher/issues/201 for more informations