### PR TITLE
Base on alpine:edge to get DNS fixes

### DIFF
--- a/mysql-backup-s3/Dockerfile
+++ b/mysql-backup-s3/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:edge
 MAINTAINER Johannes Schickling "schickling.j@gmail.com"
 
 ADD install.sh install.sh


### PR DESCRIPTION
Fix from official phpMyAdmin: https://github.com/phpmyadmin/docker/commit/6dd6b90902e4a124ce20e93f3b456f23b30855d1

See https://twitter.com/thockin/status/704909611279781888 and
gliderlabs/docker-alpine#8. This will be fixed
in 3.4, so at that point we can switch back to using stable.

Fixes [#23](https://github.com/phpmyadmin/docker/issues/23) (DNS issues)
Fixes [#27](https://github.com/phpmyadmin/docker/issues/27) (Kubernetes support)