### PR TITLE
Add the option to have 1 file per database

### DIFF
--- a/mysql-backup-s3/Dockerfile
+++ b/mysql-backup-s3/Dockerfile
@@ -5,7 +5,7 @@ ADD install.sh install.sh
 RUN sh install.sh && rm install.sh
 
 ENV MYSQLDUMP_OPTIONS --quote-names --quick --add-drop-table --add-locks --allow-keywords --disable-keys --extended-insert --single-transaction --create-options --comments --net_buffer_length=16384
-ENV MYSQLDUMP_DATABASES *ALL_IN_ONE*
+ENV MYSQLDUMP_DATABASE --all-databases
 ENV MYSQL_HOST **None**
 ENV MYSQL_PORT 3306
 ENV MYSQL_USER **None**
@@ -14,7 +14,8 @@ ENV S3_ACCESS_KEY_ID **None**
 ENV S3_SECRET_ACCESS_KEY **None**
 ENV S3_BUCKET **None**
 ENV S3_REGION us-west-1
-ENV S3_PATH 'backup'
+ENV S3_PREFIX 'backup'
+ENV MULTI_FILES no
 ENV SCHEDULE **None**
 
 ADD run.sh run.sh

--- a/mysql-backup-s3/Dockerfile
+++ b/mysql-backup-s3/Dockerfile
@@ -5,7 +5,7 @@ ADD install.sh install.sh
 RUN sh install.sh && rm install.sh
 
 ENV MYSQLDUMP_OPTIONS --quote-names --quick --add-drop-table --add-locks --allow-keywords --disable-keys --extended-insert --single-transaction --create-options --comments --net_buffer_length=16384
-ENV MYSQLDUMP_DATABASE --all-databases
+ENV MYSQLDUMP_DATABASES *ALL_IN_ONE*
 ENV MYSQL_HOST **None**
 ENV MYSQL_PORT 3306
 ENV MYSQL_USER **None**

--- a/mysql-backup-s3/README.md
+++ b/mysql-backup-s3/README.md
@@ -1,12 +1,28 @@
 # mysql-backup-s3
 
-Backup MySQL to S3 (supports periodic backups)
+Backup MySQL to S3 (supports periodic backups & mutli files)
 
-## Usage
+## Basic usage
 
 ```sh
 $ docker run -e S3_ACCESS_KEY_ID=key -e S3_SECRET_ACCESS_KEY=secret -e S3_BUCKET=my-bucket -e S3_PREFIX=backup -e MYSQL_USER=user -e MYSQL_PASSWORD=password -e MYSQL_HOST=localhost schickling/mysql-backup-s3
 ```
+
+## Environment variables
+
+- `MYSQLDUMP_OPTIONS` mysqldump options (default: --quote-names --quick --add-drop-table --add-locks --allow-keywords --disable-keys --extended-insert --single-transaction --create-options --comments --net_buffer_length=16384)
+- `MYSQLDUMP_DATABASE` list of databases you want to backup (default: --all-databases)
+- `MYSQL_HOST` the mysql host *required*
+- `MYSQL_PORT` the mysql port (default: 3306)
+- `MYSQL_USER` the mysql user *required*
+- `MYSQL_PASSWORD` the mysql password *required*
+- `S3_ACCESS_KEY_ID` your AWS access key *required*
+- `S3_SECRET_ACCESS_KEY` your AWS secret key *required*
+- `S3_BUCKET` your AWS S3 bucket path *required*
+- `S3_PREFIX` path prefix in your bucket (default: 'backup')
+- `S3_REGION` the AWS S3 bucket region (default: us-west-1)
+- `MULTI_FILES` Allow to have one file per database if set `yes` default: no)
+- `SCHEDULE` backup schedule time, see explainatons below
 
 ### Automatic Periodic Backups
 

--- a/mysql-backup-s3/backup.sh
+++ b/mysql-backup-s3/backup.sh
@@ -2,32 +2,32 @@
 
 set -e
 
-if [ "${S3_ACCESS_KEY_ID}" = "**None**" ]; then
+if [ "${S3_ACCESS_KEY_ID}" == "**None**" ]; then
   echo "You need to set the S3_ACCESS_KEY_ID environment variable."
   exit 1
 fi
 
-if [ "${S3_SECRET_ACCESS_KEY}" = "**None**" ]; then
+if [ "${S3_SECRET_ACCESS_KEY}" == "**None**" ]; then
   echo "You need to set the S3_SECRET_ACCESS_KEY environment variable."
   exit 1
 fi
 
-if [ "${S3_BUCKET}" = "**None**" ]; then
+if [ "${S3_BUCKET}" == "**None**" ]; then
   echo "You need to set the S3_BUCKET environment variable."
   exit 1
 fi
 
-if [ "${MYSQL_HOST}" = "**None**" ]; then
+if [ "${MYSQL_HOST}" == "**None**" ]; then
   echo "You need to set the MYSQL_HOST environment variable."
   exit 1
 fi
 
-if [ "${MYSQL_USER}" = "**None**" ]; then
+if [ "${MYSQL_USER}" == "**None**" ]; then
   echo "You need to set the MYSQL_USER environment variable."
   exit 1
 fi
 
-if [ "${MYSQL_PASSWORD}" = "**None**" ]; then
+if [ "${MYSQL_PASSWORD}" == "**None**" ]; then
   echo "You need to set the MYSQL_PASSWORD environment variable or link to a container named MYSQL."
   exit 1
 fi
@@ -37,14 +37,73 @@ export AWS_ACCESS_KEY_ID=$S3_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY=$S3_SECRET_ACCESS_KEY
 export AWS_DEFAULT_REGION=$S3_REGION
 
-MYSQL_HOST_OPTS="-h $MYSQL_HOST --port $MYSQL_PORT -u $MYSQL_USER -p$MYSQL_PASSWORD"
+MYSQL_HOST_OPTS="-h $MYSQL_HOST -P $MYSQL_PORT -u$MYSQL_USER -p$MYSQL_PASSWORD"
+DUMP_START_TIME=$(date +"%Y-%m-%dT%H%M%SZ")
 
-echo "Creating dump of ${MYSQLDUMP_DATABASE} database(s) from ${MYSQL_HOST}..."
+copy_s3 () {
+  SRC_FILE=$1
+  DEST_FILE=$2
 
-mysqldump $MYSQL_HOST_OPTS $MYSQLDUMP_OPTIONS $MYSQLDUMP_DATABASE | gzip > dump.sql.gz
+  echo "Uploading ${DEST_FILE} on S3..."
 
-echo "Uploading dump to $S3_BUCKET"
+  cat $SRC_FILE | aws s3 cp - s3://$S3_BUCKET/$S3_PREFIX/$DEST_FILE
 
-cat dump.sql.gz | aws s3 cp - s3://$S3_BUCKET/$S3_PREFIX/$(date +"%Y-%m-%dT%H%M%SZ").sql.gz || exit 2
+  if [ $? != 0 ]; then
+    >&2 echo "Error uploading ${DEST_FILE} on S3"
+  fi
 
-echo "SQL backup uploaded successfully"
+  rm $SRC_FILE
+}
+
+if [ "${MYSQLDUMP_DATABASES}" == "*ALL_IN_ONE*" ]; then
+  echo "Creating dump of all databases from ${MYSQL_HOST}..."
+
+  DUMP_FILE="/tmp/dump.sql.gz"
+  mysqldump $MYSQL_HOST_OPTS $MYSQLDUMP_OPTIONS --all-databases | gzip > $DUMP_FILE
+
+  if [ $? == 0 ]; then
+    S3_FILE="${DUMP_START_TIME}.${DB}.sql.gz"
+
+    copy_s3 $DUMP_FILE $S3_FILE
+  else
+    >&2 echo "Error creating dump of all databases"
+  fi
+elif [ "${MYSQLDUMP_DATABASES}" == "*ALL*" ]; then
+  echo "Mysql options ${MYSQL_HOST_OPTS}";
+  DATABASES=`mysql $MYSQL_HOST_OPTS -e "SHOW DATABASES;" | grep -Ev "(Database|information_schema|performance_schema|mysql)"`
+
+  for DB in $DATABASES; do
+    echo "Creating dump of ${DB} database from ${MYSQL_HOST}..."
+
+    DUMP_FILE="/tmp/${DB}.sql.gz"
+
+    mysqldump $MYSQL_HOST_OPTS $MYSQLDUMP_OPTIONS --databases $DB | gzip > $DUMP_FILE
+
+    if [ $? == 0 ]; then
+      S3_FILE="${DUMP_START_TIME}.${DB}.sql.gz"
+
+      copy_s3 $DUMP_FILE $S3_FILE
+    else
+      >&2 echo "Error creating dump of ${DB}"
+    fi
+  done
+
+else
+  for DB in $MYSQLDUMP_DATABASES; do
+    echo "Creating dump of ${DB} database from ${MYSQL_HOST}..."
+
+    DUMP_FILE="/tmp/${DB}.sql.gz"
+
+    mysqldump $MYSQL_HOST_OPTS $MYSQLDUMP_OPTIONS --databases $DB | gzip > $DUMP_FILE
+
+    if [ $? == 0 ]; then
+      S3_FILE="${DUMP_START_TIME}.${DB}.sql.gz"
+
+      copy_s3 $DUMP_FILE $S3_FILE
+    else
+      >&2 echo "Error creating dump of database ${DB}"
+    fi
+  done
+fi
+
+echo "SQL backup finished"


### PR DESCRIPTION
I changed the `MYSQLDUMP_DATABASE` env to have special values with different behaviours:

- `*ALL_IN_ONE*` create one big sql with all databases
- `*ALL*` create one sql per database for all databases
- `db1 db2` will create one sql for db1 & one for db2 (different from before)

I have a bit change the interface with this but I couldn't leave the `MYSQLDUMP_DATABASE` env var in singular.

If you want I can add a line for retro compatibility, something like :

```sh
if [ "${MYSQLDUMP_DATABASE}" != "" ]; then
  MYSQLDUMP_DATABASES=MYSQLDUMP_DATABASE
fi
```