### PR TITLE
make beanstalkd-console lighter with using php:7-alpine base image

### DIFF
--- a/beanstalkd-console/Dockerfile
+++ b/beanstalkd-console/Dockerfile
@@ -1,8 +1,9 @@
-FROM php:5.6
+FROM php:7-alpine
 MAINTAINER Johannes Schickling "schickling.j@gmail.com"
 
 ADD install.sh install.sh
-RUN chmod +x install.sh && ./install.sh && rm install.sh
+RUN chmod +x install.sh
+RUN ./install.sh && rm install.sh
 
 EXPOSE 2080
-CMD bash -c 'BEANSTALK_SERVERS=$BEANSTALKD_PORT_11300_TCP_ADDR:11300 php -S 0.0.0.0:2080 -t /source/public'
+CMD sh -c 'BEANSTALK_SERVERS=$BEANSTALKD_PORT_11300_TCP_ADDR:11300 php -S 0.0.0.0:2080 -t /source/public'

--- a/beanstalkd-console/install.sh
+++ b/beanstalkd-console/install.sh
@@ -1,15 +1,11 @@
-#! /bin/bash
+#! /bin/sh
 
 # exit if a command fails
 set -e
-
-# install curl (needed to install rust)
-apt-get update && apt-get install -y curl
 
 # download
 curl -sL https://github.com/ptrofimov/beanstalk_console/archive/master.tar.gz | tar xvz -C /tmp
 mv /tmp/beanstalk_console-master /source
 
-# cleanup package manager
-apt-get remove --purge -y curl && apt-get autoclean && apt-get clean
-rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# remove tmp files
+rm -rf /tmp/*


### PR DESCRIPTION

These changes applied to `beanstalkd-console` image  
- changed base image to `php:7-alpine` from `php:5.6` (reduced size because don't using debian base image)
- removed installing `curl` command (`php:7-alpine` has curl inside its image)
- changed `bash` to `sh` because alpine didn't have bash (at this time no need to install it, `sh` works fine)

Image size reduced from `~350MB` to `~57MB`