### PR TITLE
added ability to use authentication with environment variables to beanstalkd-console

### DIFF
--- a/beanstalkd-console/Dockerfile
+++ b/beanstalkd-console/Dockerfile
@@ -5,5 +5,7 @@ ADD install.sh install.sh
 RUN chmod +x install.sh
 RUN ./install.sh && rm install.sh
 
+COPY config.php /source/config.php
+
 EXPOSE 2080
 CMD sh -c 'BEANSTALK_SERVERS=$BEANSTALKD_PORT_11300_TCP_ADDR:11300 php -S 0.0.0.0:2080 -t /source/public'

--- a/beanstalkd-console/README.md
+++ b/beanstalkd-console/README.md
@@ -10,3 +10,18 @@ $ docker run -d -p 2080:2080 --link beanstalkd:beanstalkd schickling/beanstalkd-
 ```
 
 `beanstalkd-console` automatically works when the Beanstalkd docker container is linked as `beanstalkd` since it populates the `BEANSTALK_SERVERS` environment variable with `$BEANSTALKD_PORT_11300_TCP_ADDR:11300`.
+
+## Authentication (Basic Auth)
+For using basic auth in console should add these environment variables:  
+`AUTH=enable`  
+`AUTH_USERNAME=username` (default is `admin`)  
+`AUTH_PASSWORD=password` (default is `password`)  
+To run console with auth use this command:  
+```sh
+docker run -d -p 2080:2080 --link beanstalkd:beanstalkd -e AUTH=enable -e AUTH_USERNAME=admin -e AUTH_PASSWORD=password schickling/beanstalkd-console
+```
+
+
+
+
+

--- a/beanstalkd-console/config.php
+++ b/beanstalkd-console/config.php
@@ -1,0 +1,25 @@
+<?php
+
+$GLOBALS['config'] = array(
+    /**
+     * List of servers available for all users
+     */
+    'servers' => array(/* 'Local Beanstalkd' => 'beanstalk://localhost:11300', ... */),
+    /**
+     * Saved samples jobs are kept in this file, must be writable
+     */
+    'storage' => dirname(__FILE__) . DIRECTORY_SEPARATOR . 'storage.json',
+    /**
+     * Optional Basic Authentication
+     */
+    'auth' => array(
+        'enabled' => getenv('AUTH') == 'enable' ? true : false,
+        'username' => getenv('AUTH_USERNAME') ?: 'admin',
+        'password' => getenv('AUTH_PASSWORD') ?: 'password',
+    ),
+    /**
+     * Version number
+     */
+    'version' => '1.7.4',
+);
+


### PR DESCRIPTION
I added ability to use Basic Authentication in beanstalkd-console image.  
`config.php` file copied from source & modified these three lines:  
```php
'auth' => array(
        'enabled' => getenv('AUTH') == 'enable' ? true : false,
        'username' => getenv('AUTH_USERNAME') ?: 'admin',
        'password' => getenv('AUTH_PASSWORD') ?: 'password',
    ),
```  
I hope this feature is useful for managing beanstalkd securely  on server.
