### PR TITLE
Fix #28: make swagger-ui/run.sh forward signals to the Node.js process

### DIFF
--- a/swagger-ui/run.sh
+++ b/swagger-ui/run.sh
@@ -16,4 +16,4 @@ else
   sed -i "s|http://example.com/api|$API_URL|g" index.html
 fi
 
-http-server -p 80
+exec http-server -p 80


### PR DESCRIPTION
`docker stop` now properly stops the swagger-ui container