### PR TITLE
 Allow overriding of default serving port for Swagger UI

### DIFF
--- a/swagger-ui/Dockerfile
+++ b/swagger-ui/Dockerfile
@@ -6,6 +6,7 @@ ENV FOLDER "swagger-ui-2.2.0"
 ENV API_URL "http://petstore.swagger.io/v2/swagger.json"
 ENV API_KEY "**None**"
 ENV SWAGGER_JSON "/app/swagger.json"
+ENV PORT 80
 
 WORKDIR /app
 

--- a/swagger-ui/README.md
+++ b/swagger-ui/README.md
@@ -12,3 +12,4 @@ $ docker run -d -p 80:80 -e API_URL=http://localhost:4000/swagger schickling/swa
 
 * `API_URL` - Swagger endpoint for your API
 * `API_KEY` - Default API Key (optional)
+* `PORT`    - Default port to run on (optional)

--- a/swagger-ui/run.sh
+++ b/swagger-ui/run.sh
@@ -16,4 +16,4 @@ else
   sed -i "s|http://example.com/api|$API_URL|g" index.html
 fi
 
-exec http-server -p 80
+exec http-server -p $PORT $*


### PR DESCRIPTION
- allows for overriding of the serving port. this could usually be specified with ```CMD``` however, because ```-p``` is already provided, you cannot overload and define it twice with a trailing command arg. this just sets a default

- captures $* to allow extra commands to be passed in
