### PR TITLE
Upgrade alpine version from 3.2 to 3.4 for pgbackup images

### DIFF
--- a/postgres-backup-s3/Dockerfile
+++ b/postgres-backup-s3/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.2
+FROM alpine:3.4
 MAINTAINER Johannes Schickling "schickling.j@gmail.com"
 
 ADD install.sh install.sh

--- a/postgres-restore-s3/Dockerfile
+++ b/postgres-restore-s3/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.2
+FROM alpine:3.4
 MAINTAINER Johannes Schickling "schickling.j@gmail.com"
 
 ADD install.sh install.sh


### PR DESCRIPTION
Version 3.2 has an incompatibility with docker cloud: it cannot resolve services, due to a resolv.conf issue, so connecting to a `database` service or container by name to perform the backup fails with a "cannot resolve" error.

Latest version of alpine seems to work fine.
