### PR TITLE
Remove colon in time portion of archive filename

### DIFF
--- a/postgres-backup-s3/backup.sh
+++ b/postgres-backup-s3/backup.sh
@@ -57,6 +57,6 @@ pg_dump $POSTGRES_HOST_OPTS $POSTGRES_DATABASE | gzip > dump.sql.gz
 
 echo "Uploading dump to $S3_BUCKET"
 
-cat dump.sql.gz | aws s3 cp - s3://$S3_BUCKET/$S3_PREFIX/$(date +"%Y-%m-%dT%H:%M:%SZ").sql.gz || exit 2
+cat dump.sql.gz | aws s3 cp - s3://$S3_BUCKET/$S3_PREFIX/$(date +"%Y-%m-%dT%H%M%SZ").sql.gz || exit 2
 
 echo "SQL backup uploaded successfully"


### PR DESCRIPTION
Still valid ISO8601 datetime

Same as #8 for mysql-backup-s3

This has implication for postgres-backup-s3 but only for backups made within the same day after switching to this version. (Sorting will be wrong for backups made before and after, but again to re-emphasize - the effect is temporary and lasts only until the end of the day. So not really an issue IMO.)
