### PR TITLE
Switching from alpine:edge to :latest makes the thing actually build.

### DIFF
--- a/mysql-backup-s3/Dockerfile
+++ b/mysql-backup-s3/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:latest
 MAINTAINER Johannes Schickling "schickling.j@gmail.com"
 
 ADD install.sh install.sh


### PR DESCRIPTION
Apparently the package repo for edge is not compatible with the requirements your image has. It's fixed by picking latest instead of edge... Although to be safe, maybe you should actually pick the version specifically, i.e. 3.4 ?