### PR TITLE
Support for custom OAUTH2 param definition

### DIFF
--- a/swagger-ui/Dockerfile
+++ b/swagger-ui/Dockerfile
@@ -5,6 +5,11 @@ ENV VERSION "v2.2.6"
 ENV FOLDER "swagger-ui-2.2.6"
 ENV API_URL "http://petstore.swagger.io/v2/swagger.json"
 ENV API_KEY "**None**"
+ENV OAUTH_CLIENT_ID "**None**"
+ENV OAUTH_CLIENT_SECRET "**None**"
+ENV OAUTH_REALM "**None**"
+ENV OAUTH_APP_NAME "**None**"
+ENV OAUTH_ADDITIONAL_PARAMS "**None**"
 ENV SWAGGER_JSON "/app/swagger.json"
 ENV PORT 80
 

--- a/swagger-ui/README.md
+++ b/swagger-ui/README.md
@@ -1,6 +1,6 @@
 # swagger-ui
 
-Swagger UI 2.2.6 with API_URL and API_KEY injection (45 MB)
+Swagger UI 2.2.6 with API_URL, API_KEY and OAUTH2 injection (45 MB)
 
 ## Usage
 
@@ -12,5 +12,12 @@ $ docker run -d -p 80:80 -e API_URL=http://localhost:4000/swagger schickling/swa
 
 * `API_URL` - Swagger endpoint for your API
 * `API_KEY` - Default API Key (optional)
-* `PORT`    - Default port to run on (optional)
+* `PORT` - Default port to run on (optional)
 * `VALIDATOR_URL` - Swagger validator (optional)
+* `OAUTH_CLIENT_ID` - oAuth2 client ID (optional, use empty to remove)
+* `OAUTH_CLIENT_SECRET` - oAuth2 client secret (optional, use empty to remove)
+* `OAUTH_REALM` - oAuth2 realm (optional, use empty to remove)
+* `OAUTH_APP_NAME` - oAuth2 app name (optional, use empty to remove)
+* `OAUTH_ADDITIONAL_PARAMS` - oAuth2 query string additional params (optional)
+
+Variable value `**None**` should not be used for above defined variables.

--- a/swagger-ui/run.sh
+++ b/swagger-ui/run.sh
@@ -2,10 +2,29 @@
 
 set -e
 
-if [ "$API_KEY" != "**None**" ]; then
-  sed -i "s|/\*||g" index.html
-  sed -i "s|\*/||g" index.html
-  sed -i "s|myApiKeyXXXX123456789|$API_KEY|g" index.html
+replace_in_index () {
+  if [ "$1" != "**None**" ]; then
+    sed -i "s|/\*||g" index.html
+    sed -i "s|\*/||g" index.html
+    sed -i "s|$1|$2|g" index.html
+  fi
+}
+
+replace_or_delete_in_index () {
+  if [ -z "$2" ]; then
+    sed -i "/$1/d" index.html
+  else
+    replace_in_index $1 $2
+  fi
+}
+
+replace_in_index myApiKeyXXXX123456789 $API_KEY
+replace_or_delete_in_index your-client-id $OAUTH_CLIENT_ID
+replace_or_delete_in_index your-client-secret-if-required $OAUTH_CLIENT_SECRET
+replace_or_delete_in_index your-realms $OAUTH_REALM
+replace_or_delete_in_index your-app-name $OAUTH_APP_NAME
+if [ "$OAUTH_ADDITIONAL_PARAMS" != "**None**" ]; then
+    replace_in_index "additionalQueryStringParams: {}" "additionalQueryStringParams: {$OAUTH_ADDITIONAL_PARAMS}"
 fi
 
 if [[ -f $SWAGGER_JSON ]]; then


### PR DESCRIPTION
Please accept that pull request that allow to customize this static initialization of the swagger-ui index.html :

```
initOAuth({
  clientId: "your-client-id",
  clientSecret: "your-client-secret-if-required",
  realm: "your-realms",
  appName: "your-app-name",
  scopeSeparator: ",",
  additionalQueryStringParams: {}
});
```

You can test it by :
1. running Keycloak `docker run -p 8080:8080 -e KEYCLOAK_USER=admin -e KEYCLOAK_PASSWORD=admin jboss/keycloak`
2. log into Keycloak and create a client in the master realm with name swagger-ui, implicit flow and which is public
3. run `docker run -d -p 80:80 OAUTH_CLIENT_ID=swagger-ui -e OAUTH_REALM=master -e OAUTH_ADDITIONAL_PARAMS="nonce:'123'" schickling/swagger-ui`
4. load a swagger api with a oauth2 security definition like the one bellow

```
{
  authorizationUrl: "http://localhost:8080/auth/realms/master/protocol/openid-connect/auth", 
  flow: "implicit", 
  type: "oauth2",
  scopes: {}
}
```