### PR TITLE
Bumped alpine version to edge to get pg_dump version 9.6.1

### DIFF
--- a/postgres-backup-s3/Dockerfile
+++ b/postgres-backup-s3/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:edge
 MAINTAINER Johannes Schickling "schickling.j@gmail.com"
 
 ADD install.sh install.sh

--- a/postgres-backup-s3/Dockerfile
+++ b/postgres-backup-s3/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.5
 MAINTAINER Johannes Schickling "schickling.j@gmail.com"
 
 ADD install.sh install.sh

--- a/postgres-backup-s3/install.sh
+++ b/postgres-backup-s3/install.sh
@@ -10,9 +10,9 @@ apk update
 apk add postgresql
 
 # install s3 tools
-apk add python py-pip
+apk add python py2-pip
 pip install awscli
-apk del py-pip
+apk del py2-pip
 
 # install go-cron
 apk add curl


### PR DESCRIPTION
I needed a version of your excellent image with pg_dump/postgresql version 9.6.x and made this.

I know it's not ready for a merge, but an official Docker image of Alpine 3.5 is probably just around the corner (3.5 was released 22/12). It also contains the latest pg. I'll update the PR when it's released.

Meanwhile - others can use my fork to get pg_dump version 9.6.1 :-)

Intermediate image available from here:
https://hub.docker.com/r/rostved/postgres-backup-s3/