### PR TITLE
Fix backup.sh for mysql-backup-s3

### DIFF
--- a/mysql-backup-s3/backup.sh
+++ b/mysql-backup-s3/backup.sh
@@ -44,7 +44,7 @@ copy_s3 () {
   SRC_FILE=$1
   DEST_FILE=$2
 
-  if[ "${S3_ENDPOINT}" == "**None**" ]; then
+  if [ "${S3_ENDPOINT}" == "**None**" ]; then
     AWS_ARGS=""
   else
     AWS_ARGS="--endpoint-url ${S3_ENDPOINT}"


### PR DESCRIPTION
Fix a missing space which throw an error
```
backup.sh: line 47: syntax error: unexpected "then" (expecting "}")
```