### PR TITLE
Remove hard aws credentials restriction

### DIFF
--- a/mysql-backup-s3/backup.sh
+++ b/mysql-backup-s3/backup.sh
@@ -3,13 +3,11 @@
 set -e
 
 if [ "${S3_ACCESS_KEY_ID}" == "**None**" ]; then
-  echo "You need to set the S3_ACCESS_KEY_ID environment variable."
-  exit 1
+  echo "Warning: You did not set the S3_ACCESS_KEY_ID environment variable."
 fi
 
 if [ "${S3_SECRET_ACCESS_KEY}" == "**None**" ]; then
-  echo "You need to set the S3_SECRET_ACCESS_KEY environment variable."
-  exit 1
+  echo "Warning: You did not set the S3_SECRET_ACCESS_KEY environment variable."
 fi
 
 if [ "${S3_BUCKET}" == "**None**" ]; then


### PR DESCRIPTION
AWS Credentials are not always a requirement if you are using ECS as it supports IAM Roles for Tasks.