### PR TITLE
If an IAM role is present, don't export AWS credentials.

### DIFF
--- a/mysql-backup-s3/backup.sh
+++ b/mysql-backup-s3/backup.sh
@@ -30,10 +30,12 @@ if [ "${MYSQL_PASSWORD}" == "**None**" ]; then
   exit 1
 fi
 
-# env vars needed for aws tools
-export AWS_ACCESS_KEY_ID=$S3_ACCESS_KEY_ID
-export AWS_SECRET_ACCESS_KEY=$S3_SECRET_ACCESS_KEY
-export AWS_DEFAULT_REGION=$S3_REGION
+if [ "${S3_IAMROLE}" != "true" ]; then
+  # env vars needed for aws tools - only if an IAM role is not used
+  export AWS_ACCESS_KEY_ID=$S3_ACCESS_KEY_ID
+  export AWS_SECRET_ACCESS_KEY=$S3_SECRET_ACCESS_KEY
+  export AWS_DEFAULT_REGION=$S3_REGION
+fi
 
 MYSQL_HOST_OPTS="-h $MYSQL_HOST -P $MYSQL_PORT -u$MYSQL_USER -p$MYSQL_PASSWORD"
 DUMP_START_TIME=$(date +"%Y-%m-%dT%H%M%SZ")


### PR DESCRIPTION
At present, this image can not work if you wish to use an IAM role to pass credentials to the AWS CLI. To mitigate this, allow another variable which will not export AWS credentials when defined.

```
# aws s3 cp backup.sh s3://3r-magnitude-backups/backup/backup.sh
upload: ./backup.sh to s3://3r-magnitude-backups/backup/backup.sh
# export AWS_ACCESS_KEY_ID=$S3_ACCESS_KEY_ID
# export AWS_SECRET_ACCESS_KEY=$S3_SECRET_ACCESS_KEY
# export AWS_DEFAULT_REGION=$S3_REGION
# aws s3 cp backup.sh s3://3r-magnitude-backups/backup/backup.sh
upload failed: ./backup.sh to s3://3r-magnitude-backups/backup/backup.sh An error occurred (InvalidAccessKeyId) when calling the PutObject operation: The AWS Access Key Id you provided does not exist in our records.
```