### PR TITLE
Exclude sys & innodb databases on mysql-backup-s3

### DIFF
--- a/mysql-backup-s3/backup.sh
+++ b/mysql-backup-s3/backup.sh
@@ -63,7 +63,7 @@ copy_s3 () {
 # Multi file: yes
 if [ ! -z "$(echo $MULTI_FILES | grep -i -E "(yes|true|1)")" ]; then
   if [ "${MYSQLDUMP_DATABASE}" == "--all-databases" ]; then
-    DATABASES=`mysql $MYSQL_HOST_OPTS -e "SHOW DATABASES;" | grep -Ev "(Database|information_schema|performance_schema|mysql)"`
+    DATABASES=`mysql $MYSQL_HOST_OPTS -e "SHOW DATABASES;" | grep -Ev "(Database|information_schema|performance_schema|mysql|sys|innodb)"`
   else
     DATABASES=$MYSQLDUMP_DATABASE
   fi


### PR DESCRIPTION
With the latest versions of MySQL there are new databases to exclude from bz