### PR TITLE
Fix bash typo

### DIFF
--- a/postgres-backup-s3/run.sh
+++ b/postgres-backup-s3/run.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ "${S3_S3V4}" = "yes"]; then
+if [ "${S3_S3V4}" = "yes" ]; then
     aws configure set default.s3.signature_version s3v4
 fi
 


### PR DESCRIPTION
The first line of output on a fresh container:

    sh: missing ]

Same as #65 