### PR TITLE
Use rustup for Rust installation

### DIFF
--- a/rust/install.sh
+++ b/rust/install.sh
@@ -3,18 +3,11 @@
 # exit if a command fails
 set -e
 
-triple=x86_64-unknown-linux-gnu
-
 # install curl (needed to install rust)
 apt-get update && apt-get install -y curl gdb g++-multilib lib32stdc++6 libssl-dev libncurses5-dev
 
-# install rust
-curl -sL https://static.rust-lang.org/dist/rust-nightly-$triple.tar.gz | tar xvz -C /tmp
-/tmp/rust-nightly-$triple/install.sh
-
-# install cargo
-curl -sL https://static.rust-lang.org/cargo-dist/cargo-nightly-$triple.tar.gz | tar xvz -C /tmp
-/tmp/cargo-nightly-$triple/install.sh
+# install rust + cargo nightly
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
 
 # cleanup package manager
 apt-get remove --purge -y curl && apt-get autoclean && apt-get clean


### PR DESCRIPTION
This installs a newer version than `cargo 0.16.0-nightly (3568be9 2016-11-26)`