### PR TITLE
Set PATH for cargo and rustc

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -7,6 +7,8 @@ ENV USER root
 ADD install.sh install.sh
 RUN sh install.sh && rm install.sh
 
+ENV PATH=/root/.cargo/bin:$PATH
+
 VOLUME ["/source"]
 WORKDIR /source
 CMD ["bash"]


### PR DESCRIPTION
`/root/.profile` is not executed. 