### PR TITLE
Reduce image size and useless process

### DIFF
--- a/beanstalkd/Dockerfile
+++ b/beanstalkd/Dockerfile
@@ -1,8 +1,7 @@
-FROM debian:wheezy
+FROM alpine
 LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 
-ADD install.sh install.sh
-RUN sh install.sh && rm install.sh
+RUN apk add --no-cache beanstalkd
 
 EXPOSE 11300
-CMD ["beanstalkd", "-p", "11300"]
+ENTRYPOINT ["/usr/bin/beanstalkd"]

--- a/beanstalkd/README.md
+++ b/beanstalkd/README.md
@@ -8,3 +8,7 @@ Lightweight image of the latest beanstalkd version
 $ docker run -d -p 11300:11300 schickling/beanstalkd
 ```
 
+### Add configuration parameters like this:
+```sh
+$ docker run -d -p 11300:11300 schickling/beanstalkd -b /some/dir
+```


### PR DESCRIPTION
This reduces the image size (using alpine), and removes the `/bin/sh` process by using `ENTRYPOINT`

Note that this breaks backwards compatibility since people overriding their `CMD` will have their container broken.