### PR TITLE
Update alpine from 3.7 to 3.9 in postgres-backup-s3

### DIFF
--- a/postgres-backup-s3/Dockerfile
+++ b/postgres-backup-s3/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 
 ADD install.sh install.sh


### PR DESCRIPTION
I'm unable to use this now that the default `postgres` version on Docker Hub is 11.1. In Alpine 3.9 (`latest`) the postgres version is also 11.1, so this brings it back in line.