### PR TITLE
Update mailcatcher to v0.7.1

### DIFF
--- a/mailcatcher/Dockerfile
+++ b/mailcatcher/Dockerfile
@@ -9,7 +9,7 @@ RUN set -xe \
     && apk add --no-cache --virtual .build-deps \
         build-base \
         sqlite-dev \
-    && gem install mailcatcher -v 0.6.5 --no-ri --no-rdoc \
+    && gem install mailcatcher -v 0.7.1 --no-ri --no-rdoc \
     && apk del .build-deps
 
 # smtp port


### PR DESCRIPTION
@schickling in v0.7 some utf-8 encoding problems were fixed (see https://github.com/sj26/mailcatcher/releases/tag/v0.7.0)

Would it be possible to get this merged? Thanks.