### PR TITLE
Add option to prefix backup file name with custom string

### DIFF
--- a/postgres-backup-s3/Dockerfile
+++ b/postgres-backup-s3/Dockerfile
@@ -18,6 +18,7 @@ ENV S3_PATH 'backup'
 ENV S3_ENDPOINT **None**
 ENV S3_S3V4 no
 ENV SCHEDULE **None**
+ENV DB_ENV_PREFIX **None**
 
 ADD run.sh run.sh
 ADD backup.sh backup.sh

--- a/postgres-backup-s3/README.md
+++ b/postgres-backup-s3/README.md
@@ -6,7 +6,7 @@ Backup PostgresSQL to S3 (supports periodic backups)
 
 Docker:
 ```sh
-$ docker run -e S3_ACCESS_KEY_ID=key -e S3_SECRET_ACCESS_KEY=secret -e S3_BUCKET=my-bucket -e S3_PREFIX=backup -e POSTGRES_DATABASE=dbname -e POSTGRES_USER=user -e POSTGRES_PASSWORD=password -e POSTGRES_HOST=localhost schickling/postgres-backup-s3
+$ docker run -e S3_ACCESS_KEY_ID=key -e S3_SECRET_ACCESS_KEY=secret -e S3_BUCKET=my-bucket -e S3_PREFIX=backup -e POSTGRES_DATABASE=dbname -e POSTGRES_USER=user -e POSTGRES_PASSWORD=password -e POSTGRES_HOST=localhost -e DB_ENV_PREFIX=prod schickling/postgres-backup-s3
 ```
 
 Docker Compose:
@@ -23,6 +23,7 @@ pgbackups3:
     - postgres
   environment:
     SCHEDULE: '@daily'
+    DB_ENV_PREFIX: 'prod'
     S3_REGION: region
     S3_ACCESS_KEY_ID: key
     S3_SECRET_ACCESS_KEY: secret

--- a/postgres-backup-s3/backup.sh
+++ b/postgres-backup-s3/backup.sh
@@ -66,8 +66,10 @@ echo "Creating dump of ${POSTGRES_DATABASE} database from ${POSTGRES_HOST}..."
 
 pg_dump $POSTGRES_HOST_OPTS $POSTGRES_DATABASE | gzip > dump.sql.gz
 
-echo "Uploading dump to $S3_BUCKET"
+FILENAME=${DB_ENV_PREFIX}_${POSTGRES_DATABASE}_$(date +"%Y-%m-%dT%H_%M_%SZ").sql.gz
 
-cat dump.sql.gz | aws $AWS_ARGS s3 cp - s3://$S3_BUCKET/$S3_PREFIX/${DB_ENV_PREFIX}_${POSTGRES_DATABASE}_$(date +"%Y-%m-%dT%H_%M_%SZ").sql.gz || exit 2
+echo "Uploading dump named $FILENAME to $S3_BUCKET"
+
+cat dump.sql.gz | aws $AWS_ARGS s3 cp - s3://$S3_BUCKET/$S3_PREFIX/$FILENAME || exit 2
 
 echo "SQL backup uploaded successfully"

--- a/postgres-backup-s3/backup.sh
+++ b/postgres-backup-s3/backup.sh
@@ -49,6 +49,11 @@ else
   AWS_ARGS="--endpoint-url ${S3_ENDPOINT}"
 fi
 
+if [ "${DB_ENV_PREFIX}" = "**None**" ]; then
+  echo "You need to set the DB_ENV_PREFIX environment variable."
+  exit 1
+fi
+
 # env vars needed for aws tools
 export AWS_ACCESS_KEY_ID=$S3_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY=$S3_SECRET_ACCESS_KEY
@@ -63,6 +68,6 @@ pg_dump $POSTGRES_HOST_OPTS $POSTGRES_DATABASE | gzip > dump.sql.gz
 
 echo "Uploading dump to $S3_BUCKET"
 
-cat dump.sql.gz | aws $AWS_ARGS s3 cp - s3://$S3_BUCKET/$S3_PREFIX/${POSTGRES_DATABASE}_$(date +"%Y-%m-%dT%H:%M:%SZ").sql.gz || exit 2
+cat dump.sql.gz | aws $AWS_ARGS s3 cp - s3://$S3_BUCKET/$S3_PREFIX/${DB_ENV_PREFIX}_${POSTGRES_DATABASE}_$(date +"%Y-%m-%dT%H_%M_%SZ").sql.gz || exit 2
 
 echo "SQL backup uploaded successfully"

--- a/postgres-backup-s3/install.sh
+++ b/postgres-backup-s3/install.sh
@@ -7,7 +7,7 @@ set -e
 apk update
 
 # install pg_dump
-apk add postgresql
+apk add postgresql-client
 
 # install s3 tools
 apk add python py2-pip


### PR DESCRIPTION
I thought it would be useful to have option of adding custom prefix into backup filename. Also I'm printing filename into console.

There's one more change - `postgresql-client` now contains `pg_dump` so there's no need to install whole `postgresql` package.