### PR TITLE
Update Dockerfile

### DIFF
--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:wheezy
+FROM debian:buster
 LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Debian wheezy is out of support since 2016.
Using the latest debian version buster.