### PR TITLE
Upgrade to alpine 3.10 and pg_dump version issue fixed

### DIFF
--- a/postgres-backup-s3/Dockerfile
+++ b/postgres-backup-s3/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.10
 LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 
 ADD install.sh install.sh


### PR DESCRIPTION
alpine 3.10 and postgresql 11.6-r0 , fixed pg_dump version issue
Signed-off-by: Anish Kumar Dhanka <anish.mourya5@gmail.com>
