### PR TITLE
Mailcatcher - Support for http-path

### DIFF
--- a/mailcatcher/Dockerfile
+++ b/mailcatcher/Dockerfile
@@ -9,8 +9,10 @@ RUN set -xe \
     && apk add --no-cache --virtual .build-deps \
         build-base \
         sqlite-dev \
-    && gem install mailcatcher -v 0.6.5 --no-ri --no-rdoc \
+    && gem install mailcatcher -v 0.8.0 --no-ri --no-rdoc \
     && apk del .build-deps
+
+ENV HTTPPATH="/"
 
 # smtp port
 EXPOSE 1025
@@ -18,4 +20,4 @@ EXPOSE 1025
 # webserver port
 EXPOSE 1080
 
-CMD ["mailcatcher", "--no-quit", "--foreground", "--ip=0.0.0.0"]
+CMD ["sh", "-c", "mailcatcher --no-quit --foreground --ip=0.0.0.0 --http-path $HTTPPATH"]

--- a/mailcatcher/README.md
+++ b/mailcatcher/README.md
@@ -9,3 +9,10 @@ $ docker run -d -p 1080:1080 --name mailcatcher schickling/mailcatcher
 ```
 
 Link the container to another container and use the mailcatcher SMTP port `1025` via a ENV variable like `$MAILCATCHER_PORT_1025_TCP_ADDR`.
+
+## HTTP Path Support
+You can run the web interface under a different root by specifying the environmental variable HTTPPATH. This can be used if you're proxying the incoming connection. 
+
+```sh
+$ docker run -d -p 1080:1080 -e HTTPPATH="mailcatcher" --name mailcatcher schickling/mailcatcher
+```


### PR DESCRIPTION
Adds support for http-path which was added in a later version of mailcatcher. 

This is useful for when you're running mailcatcher in a dev/test environment that is being proxied based on a URI prefix. This retains the default behaviour and will only change if the HTTPPATH env is set. 