### PR TITLE
Update Alpine to 3.15 to support PostgreSQL 14

### DIFF
--- a/postgres-backup-s3/Dockerfile
+++ b/postgres-backup-s3/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.15
 LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 
 ADD install.sh install.sh

--- a/postgres-backup-s3/install.sh
+++ b/postgres-backup-s3/install.sh
@@ -10,9 +10,9 @@ apk update
 apk add postgresql
 
 # install s3 tools
-apk add python py2-pip
+apk add python3 py3-pip
 pip install awscli
-apk del py2-pip
+apk del py3-pip
 
 # install go-cron
 apk add curl

--- a/postgres-backup-s3/install.sh
+++ b/postgres-backup-s3/install.sh
@@ -10,9 +10,7 @@ apk update
 apk add postgresql
 
 # install s3 tools
-apk add python3 py3-pip
-pip install awscli
-apk del py3-pip
+apk add aws-cli
 
 # install go-cron
 apk add curl

--- a/postgres-backup-s3/install.sh
+++ b/postgres-backup-s3/install.sh
@@ -7,7 +7,7 @@ set -eo pipefail
 apk update
 
 # install pg_dump
-apk add postgresql
+apk add postgresql-client
 
 # install s3 tools
 apk add aws-cli

--- a/postgres-restore-s3/Dockerfile
+++ b/postgres-restore-s3/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15
 LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 
 ADD install.sh install.sh

--- a/postgres-restore-s3/install.sh
+++ b/postgres-restore-s3/install.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 apk update
 
 # install pg_dump
-apk add postgresql
+apk add postgresql-client
 
 # install s3 tools
 apk add aws-cli

--- a/postgres-restore-s3/install.sh
+++ b/postgres-restore-s3/install.sh
@@ -9,9 +9,7 @@ apk update
 apk add postgresql
 
 # install s3 tools
-apk add python py-pip
-pip install awscli
-apk del py-pip
+apk add aws-cli
 
 # cleanup
 rm -rf /var/cache/apk/*


### PR DESCRIPTION
The recently merged PR #127 upgrades to Alpine `3.11`, but this does not support latest PostgreSQL `14`. I have upgraded Alpine to `3.15` for Backup & Restore and simplified installation of `aws-cli`.

My own image is on DockerHub:
https://hub.docker.com/r/ledermann/postgres-backup-s3

