### PR TITLE
Remove insecure parameter from curl commands

### DIFF
--- a/postgres-backup-s3/install.sh
+++ b/postgres-backup-s3/install.sh
@@ -14,7 +14,7 @@ apk add aws-cli
 
 # install go-cron
 apk add curl
-curl -L --insecure https://github.com/odise/go-cron/releases/download/v0.0.6/go-cron-linux.gz | zcat > /usr/local/bin/go-cron
+curl -L https://github.com/odise/go-cron/releases/download/v0.0.6/go-cron-linux.gz | zcat > /usr/local/bin/go-cron
 chmod u+x /usr/local/bin/go-cron
 apk del curl
 

--- a/s3cmd/install.sh
+++ b/s3cmd/install.sh
@@ -15,6 +15,6 @@ rm -rf /tmp/s3cmd
 
 # install go-cron
 apk add --no-cache curl
-curl -L --insecure https://github.com/odise/go-cron/releases/download/v0.0.6/go-cron-linux.gz | zcat > /usr/local/bin/go-cron
+curl -L https://github.com/odise/go-cron/releases/download/v0.0.6/go-cron-linux.gz | zcat > /usr/local/bin/go-cron
 chmod u+x /usr/local/bin/go-cron
 apk del curl


### PR DESCRIPTION
The `--insecure` parameter should not be necessary when fetching from Github.
If there is a certificate error while downloading binaries, it should be fixed, not ignored.

Fixes: #142 

Tested:
* docker build postgres-backup-s3 -> works
* docker build s3cmd -> download works, but fails later on pip install python-dateutil (most likely unrelated)