### PR TITLE
Docker images improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,92 @@
+define docker_build_and_push
+	docker buildx build \
+		--push \
+		--platform linux/arm64,linux/amd64 \
+		-t "schickling/$1" \
+		./$1
+endef
+
+help:
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[0-9a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+all: beanstalkd beanstalkd-console hugin jekyll latex mailcatcher mysql-backup-s3 nginx-envtpl nodejs octave opencv postgres-backup-s3 postgres-restore-s3 redis-commander rust s3cmd scala-sbt-docker swagger-ui thumbor-nginx-cors ## Build all images
+
+.PHONY: beanstalkd
+beanstalkd: ## Build beanstalkd image
+	$(call docker_build_and_push,beanstalkd)
+
+.PHONY: beanstalkd-console
+beanstalkd-console: ## Build beanstalkd-console image
+	$(call docker_build_and_push,beanstalkd-console)
+
+.PHONY: hugin
+hugin: ## Build hugin image
+	$(call docker_build_and_push,hugin)
+
+.PHONY: jekyll # (This image is not compatible with arm architecture)
+jekyll: ## Build jekyll image
+	docker buildx build \
+		--push \
+		--platform linux/amd64 \
+		-t "schickling/$1" \
+		./$1
+
+.PHONY: latex
+latex: ## Build latex image
+	$(call docker_build_and_push,latex)
+
+.PHONY: mailcatcher
+mailcatcher: ## Build mailcatcher image
+	$(call docker_build_and_push,mailcatcher)
+
+.PHONY: mysql-backup-s3
+mysql-backup-s3: ## Build mysql-backup-s3 image
+	$(call docker_build_and_push,mysql-backup-s3)
+
+.PHONY: nginx-envtpl
+nginx-envtpl: ## Build nginx-envtpl image
+	$(call docker_build_and_push,nginx-envtpl)
+
+.PHONY: nodejs
+nodejs: ## Build nodejs image
+	$(call docker_build_and_push,nodejs)
+
+.PHONY: octave
+octave: ## Build octave image
+	$(call docker_build_and_push,octave)
+
+.PHONY: opencv
+opencv: ## Build opencv image
+	$(call docker_build_and_push,opencv)
+
+.PHONY: postgres-backup-s3
+postgres-backup-s3: ## Build postgres-backup-s3 image
+	$(call docker_build_and_push,postgres-backup-s3)
+
+.PHONY: postgres-restore-s3
+postgres-restore-s3: ## Build postgres-restore-s3 image
+	$(call docker_build_and_push,postgres-restore-s3)
+
+.PHONY: redis-commander
+redis-commander: ## Build redis-commander image
+	$(call docker_build_and_push,redis-commander)
+
+.PHONY: rust
+rust: ## Build rust image
+	$(call docker_build_and_push,rust)
+
+.PHONY: s3cmd
+s3cmd: ## Build s3cmd image
+	$(call docker_build_and_push,s3cmd)
+
+.PHONY: scala-sbt-docker
+scala-sbt-docker: ## Build scala-sbt-docker image
+	$(call docker_build_and_push,scala-sbt-docker)
+
+.PHONY: swagger-ui
+swagger-ui: ## Build swagger-ui image
+	$(call docker_build_and_push,swagger-ui)
+
+.PHONY: thumbor-nginx-cors
+thumbor-nginx-cors: ## Build thumbor-nginx-cors image
+	$(call docker_build_and_push,thumbor-nginx-cors)

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,22 @@
+TAG := $(GITHUB_REF)
+ifeq ($(TAG),)
+	TAG := $(shell git symbolic-ref --short -q HEAD)
+endif
+ifeq ($(TAG),)
+	TAG := $(shell git rev-parse --short --verify HEAD)
+endif
+
 define docker_build_and_push
 	docker buildx build \
 		--push \
 		--platform linux/arm64,linux/amd64 \
-		-t "schickling/$1:$(if $2,$2,latest)" \
+		-t "schickling/$1:$(if $2,$2,$(TAG))" \
 		./$1
 endef
 
 help:
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[0-9a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+	@echo $(TAG)
 
 all: beanstalkd beanstalkd-console hugin jekyll latex mailcatcher mysql-backup-s3 nginx-envtpl nodejs octave opencv postgres-backup-s3 postgres-restore-s3 redis-commander rust s3cmd scala-sbt-docker swagger-ui thumbor-nginx-cors ## Build all images
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ define docker_build_and_push
 	docker buildx build \
 		--push \
 		--platform linux/arm64,linux/amd64 \
-		-t "schickling/$1" \
+		-t "schickling/$1:$(if $2,$2,latest)" \
 		./$1
 endef
 

--- a/hugin/Dockerfile
+++ b/hugin/Dockerfile
@@ -1,10 +1,10 @@
-FROM debian:jessie
+FROM debian:bullseye
 LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 
 ENV DEBIAN_FRONTEND noninteractive
 
 ADD install.sh install.sh
-RUN sh install.sh && rm install.sh
+RUN bash install.sh && rm install.sh
 
 VOLUME ["/source"]
 WORKDIR /source

--- a/jekyll/Dockerfile
+++ b/jekyll/Dockerfile
@@ -1,10 +1,10 @@
-FROM debian:wheezy
+FROM debian:bullseye
 LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 
 ENV DEBIAN_FRONTEND noninteractive
 
 ADD install.sh install.sh
-RUN sh install.sh && rm install.sh
+RUN bash install.sh && rm install.sh
 
 EXPOSE 4000
 VOLUME ["/source"]

--- a/jekyll/install.sh
+++ b/jekyll/install.sh
@@ -4,10 +4,10 @@
 set -eo pipefail
 
 # install ruby 1.9.1
-apt-get update && apt-get install -y ruby ruby-dev build-essential
+apt-get update && apt-get install -y python2 ruby ruby-dev build-essential
 
 # install jekyll & bundler (therubyracer needed for coffeescript support, rouge for highlightning)
-gem install jekyll bundler therubyracer rouge --no-ri --no-rdoc
+gem install jekyll bundler therubyracer rouge --no-document
 
 # cleanup package manager
 apt-get remove --purge -y build-essential ruby-dev && apt-get autoclean && apt-get clean

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 ENV DEBIAN_FRONTEND noninteractive
 
 ADD install.sh install.sh
-RUN sh install.sh && rm install.sh
+RUN bash install.sh && rm install.sh
 
 VOLUME ["/source"]
 WORKDIR /source

--- a/nginx-envtpl/Dockerfile
+++ b/nginx-envtpl/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
             python-setuptools \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN pip install envtpl
+RUN pip2 install envtpl
 
 COPY entrypoint.sh /
 

--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 ENV DEBIAN_FRONTEND noninteractive
 
 ADD install.sh install.sh
-RUN sh install.sh && rm install.sh
+RUN bash install.sh && rm install.sh
 
 VOLUME ["/source"]
 WORKDIR /source

--- a/octave/Dockerfile
+++ b/octave/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 ENV DEBIAN_FRONTEND noninteractive
 
 ADD install.sh install.sh
-RUN sh install.sh && rm install.sh
+RUN bash install.sh && rm install.sh
 
 VOLUME ["/source"]
 WORKDIR /source

--- a/redis-commander/Dockerfile
+++ b/redis-commander/Dockerfile
@@ -1,10 +1,10 @@
-FROM debian:jessie
+FROM debian:bullseye
 LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 
 ENV DEBIAN_FRONTEND noninteractive
 
 ADD install.sh install.sh
-RUN sh install.sh && rm install.sh
+RUN bash install.sh && rm install.sh
 
 EXPOSE 8081
 CMD bash -c 'redis-commander --redis-host $REDIS_PORT_6379_TCP_ADDR'

--- a/redis-commander/install.sh
+++ b/redis-commander/install.sh
@@ -6,9 +6,6 @@ set -eo pipefail
 # install node & npm
 apt-get update && apt-get install -y nodejs npm
 
-# alias as node
-ln -sf /usr/bin/nodejs /usr/bin/node
-
 # install redis commander
 npm install -g redis-commander
 

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,11 +1,11 @@
-FROM debian:wheezy
+FROM debian:bullseye
 LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 
 # needed by cargo
 ENV USER root
 
 ADD install.sh install.sh
-RUN sh install.sh && rm install.sh
+RUN bash install.sh && rm install.sh
 
 ENV PATH=/root/.cargo/bin:$PATH
 

--- a/rust/install.sh
+++ b/rust/install.sh
@@ -4,7 +4,7 @@
 set -eo pipefail
 
 # install curl (needed to install rust)
-apt-get update && apt-get install -y curl gdb g++-multilib lib32stdc++6 libssl-dev libncurses5-dev
+apt-get update && apt-get install -y curl gdb
 
 # install rust + cargo nightly
 curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly

--- a/s3cmd/Dockerfile
+++ b/s3cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.15
 LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 
 ADD install.sh install.sh

--- a/s3cmd/install.sh
+++ b/s3cmd/install.sh
@@ -5,11 +5,11 @@ set -eo pipefail
 
 # install s3cmd
 apk update
-apk add --no-cache python py-pip py-setuptools git ca-certificates
+apk add --no-cache python3 py-pip py-setuptools git ca-certificates
 pip install python-magic
 git clone https://github.com/s3tools/s3cmd.git /tmp/s3cmd
 cd /tmp/s3cmd
-python setup.py install
+python3 setup.py install
 apk del git
 rm -rf /tmp/s3cmd
 

--- a/scala-sbt-docker/Dockerfile
+++ b/scala-sbt-docker/Dockerfile
@@ -5,24 +5,22 @@ FROM openjdk:8
 # START COPY FROM https://github.com/hseeberger/scala-sbt/blob/master/Dockerfile
 ###
 
-ENV SCALA_VERSION 2.12.1
-ENV SBT_VERSION 0.13.13
+ENV SCALA_VERSION 2.13.8
+ENV SBT_VERSION 1.6.2
 
 # Install Scala
 ## Piping curl directly in tar
 RUN \
-  curl -fsL http://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ && \
+  curl -fsL https://downloads.lightbend.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ && \
   echo >> /root/.bashrc && \
   echo 'export PATH=~/scala-$SCALA_VERSION/bin:$PATH' >> /root/.bashrc
 
 # Install sbt
 RUN \
-  curl -L -o sbt-$SBT_VERSION.deb http://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb && \
-  dpkg -i sbt-$SBT_VERSION.deb && \
-  rm sbt-$SBT_VERSION.deb && \
-  apt-get update && \
-  apt-get install sbt && \
-  sbt sbtVersion
+  curl -fsL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | tar xfz - -C /usr/share && \
+  chown -R root:root /usr/share/sbt && \
+  chmod -R 755 /usr/share/sbt && \
+  ln -s /usr/share/sbt/bin/sbt /usr/local/bin/sbt
 
 # Define working directory
 WORKDIR /root


### PR DESCRIPTION
Related to #144

This PR add a `Makefile` to build all image with the `arm` compatibility.
All image are compatible except the `jekyll` image (it requires `therubyracer` dependency which need to install `v8` which is not compatible with arm architecture).

When I've tested the `Makefile`, I've notice a lot of image build are broken.
So I fix them.