### PR TITLE
bump ruby and mailcatcher versions

### DIFF
--- a/mailcatcher/Dockerfile
+++ b/mailcatcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-alpine3.6
+FROM ruby:2.7.6-alpine3.15
 
 LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 
@@ -9,7 +9,7 @@ RUN set -xe \
     && apk add --no-cache --virtual .build-deps \
         build-base \
         sqlite-dev \
-    && gem install mailcatcher -v 0.8.0 --no-ri --no-rdoc \
+    && gem install mailcatcher -v 0.8.2 -N \
     && apk del .build-deps
 
 ENV HTTPPATH="/"


### PR DESCRIPTION
- bump ruby 2.4 to 2.7.6
- bump alpine 3.6 to 3.15
- bump mailcatcher 0.8.0 to 0.8.2