### PR TITLE
Add support for MySQL 8.0

### DIFF
--- a/mysql-backup-s3/install.sh
+++ b/mysql-backup-s3/install.sh
@@ -7,6 +7,7 @@ apk update
 
 # install mysqldump
 apk add mysql-client
+apk add apk add mariadb-connector-c
 
 # install s3 tools
 apk add python3 py3-pip


### PR DESCRIPTION
MySQL 8.0 supports only caching_sha2_password algorithm. Since alpine uses the mariadb packages for this, you need to install the missing plugins so the mysql client can use the `caching_sha2_password` algorithm.