### PR TITLE
[FIX] mysql-backup-s3 image build fails due to apk add specified twice on install.sh

### DIFF
--- a/mysql-backup-s3/install.sh
+++ b/mysql-backup-s3/install.sh
@@ -7,7 +7,7 @@ apk update
 
 # install mysqldump
 apk add mysql-client
-apk add apk add mariadb-connector-c
+apk add mariadb-connector-c
 
 # install s3 tools
 apk add python3 py3-pip


### PR DESCRIPTION
Hi!

After introducing MySQL 8.0 supports from this PR https://github.com/schickling/dockerfiles/pull/149 the docker image build fails due to `apk add specified` twice

```
root@dckh:~/builder # docker build . 
Sending build context to Docker daemon  11.26kB
Step 1/23 : FROM alpine:latest
 ---> e66264b98777
Status: Downloaded newer image for alpine:latest
 ---> e66264b98777
Step 2/23 : LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 ---> Running in 58bb36ed8f9c
Removing intermediate container 58bb36ed8f9c
 ---> db976b5d536b
Step 3/23 : ADD install.sh install.sh
 ---> 465569639c73
Step 4/23 : RUN sh install.sh && rm install.sh
 ---> Running in 44a57b5d2113
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
v3.16.0-172-gb70d4192e1 [https://dl-cdn.alpinelinux.org/alpine/v3.16/main]
v3.16.0-174-g785f8a32d1 [https://dl-cdn.alpinelinux.org/alpine/v3.16/community]
OK: 17025 distinct packages available
(1/7) Installing mariadb-common (10.6.8-r0)
(2/7) Installing libgcc (11.2.1_git20220219-r2)
(3/7) Installing ncurses-terminfo-base (6.3_p20220521-r0)
(4/7) Installing ncurses-libs (6.3_p20220521-r0)
(5/7) Installing libstdc++ (11.2.1_git20220219-r2)
(6/7) Installing mariadb-client (10.6.8-r0)
(7/7) Installing mysql-client (10.6.8-r0)
Executing busybox-1.35.0-r13.trigger
OK: 39 MiB in 21 packages
  add (no such package):
ERROR: unable to select packages:
    required by: world[add]
  apk (no such package):
    required by: world[apk]
The command '/bin/sh -c sh install.sh && rm install.sh' returned a non-zero code: 2
```