### PR TITLE
Support extra options in mysql-backup-s3's dump

### DIFF
--- a/mysql-backup-s3/Dockerfile
+++ b/mysql-backup-s3/Dockerfile
@@ -5,6 +5,7 @@ ADD install.sh install.sh
 RUN sh install.sh && rm install.sh
 
 ENV MYSQLDUMP_OPTIONS --quote-names --quick --add-drop-table --add-locks --allow-keywords --disable-keys --extended-insert --single-transaction --create-options --comments --net_buffer_length=16384
+ENV MYSQLDUMP_EXTRA_OPTIONS ''
 ENV MYSQLDUMP_DATABASE --all-databases
 ENV MYSQL_HOST **None**
 ENV MYSQL_PORT 3306

--- a/mysql-backup-s3/README.md
+++ b/mysql-backup-s3/README.md
@@ -11,6 +11,7 @@ $ docker run -e S3_ACCESS_KEY_ID=key -e S3_SECRET_ACCESS_KEY=secret -e S3_BUCKET
 ## Environment variables
 
 - `MYSQLDUMP_OPTIONS` mysqldump options (default: --quote-names --quick --add-drop-table --add-locks --allow-keywords --disable-keys --extended-insert --single-transaction --create-options --comments --net_buffer_length=16384)
+- `MYSQLDUMP_EXTRA_OPTIONS` add mysqldump options without overriding the default `MYSQLDUMP_OPTIONS` (default: empty)
 - `MYSQLDUMP_DATABASE` list of databases you want to backup (default: --all-databases)
 - `MYSQL_HOST` the mysql host *required*
 - `MYSQL_PORT` the mysql port (default: 3306)

--- a/mysql-backup-s3/backup.sh
+++ b/mysql-backup-s3/backup.sh
@@ -69,6 +69,12 @@ copy_s3 () {
 
   rm $SRC_FILE
 }
+
+# mysqldump extra options
+if [ ! -z "${MYSQLDUMP_EXTRA_OPTIONS}" ]; then
+  MYSQLDUMP_OPTIONS="${MYSQLDUMP_OPTIONS} ${MYSQLDUMP_EXTRA_OPTIONS}"
+fi
+
 # Multi file: yes
 if [ ! -z "$(echo $MULTI_FILES | grep -i -E "(yes|true|1)")" ]; then
   if [ "${MYSQLDUMP_DATABASE}" == "--all-databases" ]; then


### PR DESCRIPTION
`MYSQLDUMP_OPTIONS` allowed to set the `mysqldump` command options, but implied setting once again the defaults that the current image already has. The new `MYSQLDUMP_EXTRA_OPTIONS` gets concatenated to the other variable, allowing the user to add without having to repeat the defaults.