### PR TITLE
Add port binding in the mailcatcher documentation

### DIFF
--- a/mailcatcher/README.md
+++ b/mailcatcher/README.md
@@ -5,7 +5,7 @@ Extra small mailcatcher image (261.9 MB)
 ## Usage
 
 ```sh
-$ docker run -d -p 1080:1080 --name mailcatcher schickling/mailcatcher
+$ docker run -d -p 1080:1080 -p 1025:1025 --name mailcatcher schickling/mailcatcher
 ```
 
 Link the container to another container and use the mailcatcher SMTP port `1025` via a ENV variable like `$MAILCATCHER_PORT_1025_TCP_ADDR`.


### PR DESCRIPTION
Add port binding as suggested at #152

Before:

$ docker run -d -p 1080:1080 --name mailcatcher schickling/mailcatcher

After: 

$ docker run -d -p 1080:1080 -p 1025:1025 --name mailcatcher schickling/mailcatcher