### PR TITLE
Bump beanstalkd version to the latest (1.13)

### DIFF
--- a/beanstalkd/install.sh
+++ b/beanstalkd/install.sh
@@ -3,7 +3,7 @@
 # exit if a command fails
 set -eo pipefail
 
-version="1.11"
+version="1.13"
 
 # install curl (needed to install rust)
 apt-get update && apt-get install -y curl build-essential


### PR DESCRIPTION
Catches this Dockerfile up with the past 5 years of beanstalkd development.

I'd be grateful if this could make it's way to Docker Hub, where this Dockerfile is popular.