### PR TITLE
Upgrade postgres-backup-s3 to psql 17

### DIFF
--- a/postgres-backup-s3/Dockerfile
+++ b/postgres-backup-s3/Dockerfile
@@ -1,4 +1,4 @@
-FROM webdevops/go-crond:master-alpine
+FROM webdevops/go-crond:main-alpine
 LABEL maintainer="Johannes Schickling <schickling.j@gmail.com>"
 
 ADD install.sh install.sh

--- a/postgres-backup-s3/backup.sh
+++ b/postgres-backup-s3/backup.sh
@@ -71,7 +71,7 @@ if [ "${POSTGRES_BACKUP_ALL}" == "true" ]; then
   fi
 
   echo "Creating dump of all databases from ${POSTGRES_HOST}..."
-  pg_dumpall -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER | gzip > $SRC_FILE
+  pg_dumpall $POSTGRES_HOST_OPTS | gzip > $SRC_FILE
 
   if [ "${ENCRYPTION_PASSWORD}" != "**None**" ]; then
     echo "Encrypting ${SRC_FILE}"

--- a/postgres-backup-s3/install.sh
+++ b/postgres-backup-s3/install.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 
 apk update
 apk add openssl aws-cli 
-apk add postgresql-client --repository=https://dl-cdn.alpinelinux.org/alpine/v3.19/main
+apk add postgresql-client
 
 # cleanup
 rm -rf /var/cache/apk/*

--- a/postgres-backup-s3/run.sh
+++ b/postgres-backup-s3/run.sh
@@ -9,6 +9,6 @@ fi
 if [ "${SCHEDULE}" = "**None**" ]; then
   sh backup.sh
 else
-  echo -e "SHELL=/bin/sh\n${SCHEDULE} /bin/sh /backup.sh" > /etc/crontabs/root
+  echo -e "SHELL=/bin/sh\n${SCHEDULE} root /bin/sh /backup.sh" > /etc/crontabs/root
   exec go-crond /etc/crontabs/root
 fi


### PR DESCRIPTION
We now use alpine 3.21 as base image, which currently ships postgresql 17.5.

The upstream `go-crond` repo now uses `main` as it's base branch, so the tag name changed.