### PR TITLE
postgres-backup-s3: honor extra opts in pg_dumpall

### DIFF
--- a/postgres-backup-s3/backup.sh
+++ b/postgres-backup-s3/backup.sh
@@ -71,7 +71,7 @@ if [ "${POSTGRES_BACKUP_ALL}" == "true" ]; then
   fi
 
   echo "Creating dump of all databases from ${POSTGRES_HOST}..."
-  pg_dumpall -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER | gzip > $SRC_FILE
+  pg_dumpall $POSTGRES_HOST_OPTS | gzip > $SRC_FILE
 
   if [ "${ENCRYPTION_PASSWORD}" != "**None**" ]; then
     echo "Encrypting ${SRC_FILE}"

--- a/postgres-backup-s3/run.sh
+++ b/postgres-backup-s3/run.sh
@@ -9,6 +9,6 @@ fi
 if [ "${SCHEDULE}" = "**None**" ]; then
   sh backup.sh
 else
-  echo -e "SHELL=/bin/sh\n${SCHEDULE} /bin/sh /backup.sh" > /etc/crontabs/root
+  echo -e "SHELL=/bin/sh\n${SCHEDULE} root /bin/sh /backup.sh" > /etc/crontabs/root
   exec go-crond /etc/crontabs/root
 fi


### PR DESCRIPTION
The setting was being used in `psql`, but not when POSTGRES_BACKUP_ALL is set.